### PR TITLE
Implement chain and manager editing pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,8 @@ import CampaignList from "./CampaignList";
 import CampaignForm from "./CampaignForm";
 import Chains from "./Chains";
 import Managers from "./Managers";
+import ChainEdit from "./ChainEdit";
+import ManagerEdit from "./ManagerEdit";
 import Users from "./Users";
 import Clients from "./Clients";
 import Login from "./Login";
@@ -28,7 +30,9 @@ function App() {
     </Route>
 
     <Route path="inventory/chains" element={<Chains />} />
+    <Route path="inventory/chains/:id/edit" element={<ChainEdit />} />
     <Route path="inventory/managers" element={<Managers />} />
+    <Route path="inventory/managers/:id/edit" element={<ManagerEdit />} />
     <Route path="inventory/users" element={<Users />} />
     <Route path="clients" element={<Clients />} />
     <Route path="login" element={<Login />} />

--- a/src/ChainEdit.js
+++ b/src/ChainEdit.js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { db } from "./firebase";
+import { doc, getDoc, updateDoc } from "firebase/firestore";
+import { Button, Stack, TextField } from "@mui/material";
+import PageWrapper from "./components/common/PageWrapper";
+import SectionTitle from "./components/common/SectionTitle";
+
+export default function ChainEdit() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({ chainName: "", share: "" });
+
+  useEffect(() => {
+    const load = async () => {
+      const snap = await getDoc(doc(db, "chains", id));
+      if (snap.exists()) {
+        const data = snap.data();
+        setFormData({ chainName: data.chainName || "", share: data.share || "" });
+      }
+    };
+    load();
+  }, [id]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await updateDoc(doc(db, "chains", id), {
+      chainName: formData.chainName,
+      share: formData.share,
+    });
+    navigate("/inventory/chains");
+  };
+
+  return (
+    <PageWrapper>
+      <SectionTitle>Edit Chain</SectionTitle>
+      <form onSubmit={handleSubmit}>
+        <Stack spacing={2} sx={{ maxWidth: 400 }}>
+          <TextField
+            label="Chain Name"
+            size="small"
+            value={formData.chainName}
+            onChange={(e) => setFormData({ ...formData, chainName: e.target.value })}
+            required
+          />
+          <TextField
+            label="Share (%)"
+            size="small"
+            type="number"
+            value={formData.share}
+            onChange={(e) => setFormData({ ...formData, share: e.target.value })}
+            required
+          />
+          <Stack direction="row" spacing={2}>
+            <Button type="submit" variant="contained">Save</Button>
+            <Button variant="outlined" onClick={() => navigate("/inventory/chains")}>Cancel</Button>
+          </Stack>
+        </Stack>
+      </form>
+    </PageWrapper>
+  );
+}

--- a/src/Chains.js
+++ b/src/Chains.js
@@ -100,7 +100,7 @@ export default function Chains() {
                 <TableCell sx={tableCellSx}>{chain.share}</TableCell>
                 <TableCell sx={tableCellSx}>
                   <Stack direction="row" spacing={0}>
-                    <IconButton size="small" onClick={() => navigate(`/chains/${chain.id}/edit`)}><Edit fontSize="small" /></IconButton>
+                    <IconButton size="small" onClick={() => navigate(`/inventory/chains/${chain.id}/edit`)}><Edit fontSize="small" /></IconButton>
                     <IconButton size="small" onClick={() => handleDelete(chain.id)}><Delete fontSize="small" /></IconButton>
                   </Stack>
                 </TableCell>

--- a/src/ManagerEdit.js
+++ b/src/ManagerEdit.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { db } from "./firebase";
+import { doc, getDoc, updateDoc } from "firebase/firestore";
+import { Button, Stack, TextField } from "@mui/material";
+import PageWrapper from "./components/common/PageWrapper";
+import SectionTitle from "./components/common/SectionTitle";
+
+export default function ManagerEdit() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({ name: "", lastName: "" });
+
+  useEffect(() => {
+    const load = async () => {
+      const snap = await getDoc(doc(db, "managers", id));
+      if (snap.exists()) {
+        const data = snap.data();
+        setFormData({ name: data.name || "", lastName: data.lastName || "" });
+      }
+    };
+    load();
+  }, [id]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await updateDoc(doc(db, "managers", id), {
+      name: formData.name,
+      lastName: formData.lastName,
+    });
+    navigate("/inventory/managers");
+  };
+
+  return (
+    <PageWrapper>
+      <SectionTitle>Edit Manager</SectionTitle>
+      <form onSubmit={handleSubmit}>
+        <Stack spacing={2} sx={{ maxWidth: 400 }}>
+          <TextField
+            label="Name"
+            size="small"
+            value={formData.name}
+            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+            required
+          />
+          <TextField
+            label="Last Name"
+            size="small"
+            value={formData.lastName}
+            onChange={(e) => setFormData({ ...formData, lastName: e.target.value })}
+            required
+          />
+          <Stack direction="row" spacing={2}>
+            <Button type="submit" variant="contained">Save</Button>
+            <Button variant="outlined" onClick={() => navigate("/inventory/managers")}>Cancel</Button>
+          </Stack>
+        </Stack>
+      </form>
+    </PageWrapper>
+  );
+}

--- a/src/Managers.js
+++ b/src/Managers.js
@@ -100,7 +100,7 @@ export default function Managers() {
                 <TableCell sx={tableCellSx}>{m.lastName}</TableCell>
                 <TableCell sx={tableCellSx}>
                   <Stack direction="row" spacing={0}>
-                    <IconButton size="small" onClick={() => navigate(`/managers/${m.id}/edit`)}><Edit fontSize="small" /></IconButton>
+                    <IconButton size="small" onClick={() => navigate(`/inventory/managers/${m.id}/edit`)}><Edit fontSize="small" /></IconButton>
                     <IconButton size="small" onClick={() => handleDelete(m.id)}><Delete fontSize="small" /></IconButton>
                   </Stack>
                 </TableCell>


### PR DESCRIPTION
## Summary
- create edit forms for supermarket chains and managers
- add routes for editing chains and managers
- update edit button paths

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687919a954b8832196d4db70d3a46b75