### PR TITLE
Fix cancel navigation on CampaignForm

### DIFF
--- a/src/CampaignForm.js
+++ b/src/CampaignForm.js
@@ -500,7 +500,7 @@ export default function CampaignForm() {
 
         <Stack direction="row" spacing={2}>
             <Button type="submit" variant="contained">Save</Button>
-            <Button variant="outlined" onClick={() => navigate("/inventory/chains")}>Cancel</Button>
+            <Button variant="outlined" onClick={() => navigate("/campaigns")}>Cancel</Button>
           </Stack>
       </Box>
     </PageWrapper>


### PR DESCRIPTION
## Summary
- fix cancel button to navigate back to campaigns

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879269b13c8832199866d191030ca8e