### PR TITLE
Refactor slot calculation into shared utility

### DIFF
--- a/src/CampaignDetail.js
+++ b/src/CampaignDetail.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { doc, getDoc, getDocs, collection } from "firebase/firestore";
 import { db } from "./firebase";
+import { calculateTotalSlots } from "./utils";
 
 export default function CampaignDetail() {
   const { id } = useParams();
@@ -57,24 +58,7 @@ export default function CampaignDetail() {
       <h3>📦 Chains</h3>
       <ul>
         {campaign.chains.map((c, i) => {
-          const start = new Date(c.startDate);
-          const end = new Date(c.endDate);
-          const days = Math.ceil((end - start) / (1000 * 60 * 60 * 24)) + 1;
-          let totalSlots = 0;
-
-          if (c.slotSchedule?.type === "uniform") {
-            totalSlots = c.slotSchedule.slots * days;
-          } else if (c.slotSchedule?.type === "weekday") {
-            const weekdayCounts = {};
-            for (let j = 0; j < 7; j++) weekdayCounts[j] = 0;
-            for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-              weekdayCounts[d.getDay()]++;
-            }
-            totalSlots = Object.entries(c.slotSchedule.slots).reduce((sum, [day, slots]) => {
-              const idx = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"].indexOf(day);
-              return sum + (slots || 0) * weekdayCounts[idx];
-            }, 0);
-          }
+          const totalSlots = calculateTotalSlots(c.startDate, c.endDate, c.slotSchedule);
 
           const budget = totalSlots * c.slotPrice * c.locationCount;
 

--- a/src/CampaignForm.js
+++ b/src/CampaignForm.js
@@ -30,6 +30,7 @@ import {
 } from "@mui/material";
 import PageWrapper from "./components/common/PageWrapper";
 import SectionTitle from "./components/common/SectionTitle";
+import { calculateTotalSlots } from "./utils";
 
 export default function CampaignForm() {
   const navigate = useNavigate();
@@ -101,22 +102,7 @@ export default function CampaignForm() {
     let total = 0;
     for (let chain of formData.chains) {
       if (chain.disabled) continue;
-      const start = new Date(chain.startDate);
-      const end = new Date(chain.endDate);
-      const days = Math.ceil((end - start) / (1000 * 60 * 60 * 24)) + 1;
-      let slots = 0;
-      if (chain.slotSchedule?.type === "uniform") {
-        slots = chain.slotSchedule.slots * days;
-      } else if (chain.slotSchedule?.type === "weekday") {
-        const weekdayCounts = Array(7).fill(0);
-        for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-          weekdayCounts[d.getDay()]++;
-        }
-        slots = Object.entries(chain.slotSchedule.slots || {}).reduce((sum, [day, count]) => {
-          const idx = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].indexOf(day);
-          return sum + (count || 0) * weekdayCounts[idx];
-        }, 0);
-      }
+      const slots = calculateTotalSlots(chain.startDate, chain.endDate, chain.slotSchedule);
       total += slots * chain.slotPrice * chain.locationCount;
     }
     setCampaignBudget(total);
@@ -442,22 +428,7 @@ export default function CampaignForm() {
     <TableBody>
       {formData.chains.map((ch, i) => {
         // ...slots/budget calculation (unchanged)
-        const start = new Date(ch.startDate);
-        const end = new Date(ch.endDate);
-        const days = Math.ceil((end - start) / (1000 * 60 * 60 * 24)) + 1;
-        let slots = 0;
-        if (ch.slotSchedule?.type === "uniform") {
-          slots = ch.slotSchedule.slots * days;
-        } else if (ch.slotSchedule?.type === "weekday") {
-          const weekdayCounts = Array(7).fill(0);
-          for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-            weekdayCounts[d.getDay()]++;
-          }
-          slots = Object.entries(ch.slotSchedule.slots || {}).reduce((sum, [day, count]) => {
-            const idx = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].indexOf(day);
-            return sum + (count || 0) * weekdayCounts[idx];
-          }, 0);
-        }
+        const slots = calculateTotalSlots(ch.startDate, ch.endDate, ch.slotSchedule);
         const budget = slots * ch.slotPrice * ch.locationCount;
 
         return (

--- a/src/CampaignList.js
+++ b/src/CampaignList.js
@@ -17,6 +17,7 @@ import {
 import { Edit, Delete } from "@mui/icons-material";
 import PageWrapper from "./components/common/PageWrapper";
 import SectionTitle from "./components/common/SectionTitle";
+import { calculateTotalSlots } from "./utils";
 
 export default function CampaignList({ filteredBy }) {
   const [campaigns, setCampaigns] = useState([]);
@@ -184,13 +185,7 @@ const renderByChain = () => {
           {records.map((r, i) => {
             const start = r.chain.startDate;
             const end = r.chain.endDate;
-            const days = (new Date(end) - new Date(start)) / (1000 * 60 * 60 * 24) + 1;
-            let totalSlots = 0;
-            if (r.chain.slotSchedule?.type === "uniform") {
-              totalSlots = r.chain.slotSchedule.slots * days;
-            } else if (r.chain.slotSchedule?.type === "weekday") {
-              totalSlots = Object.values(r.chain.slotSchedule.slots || {}).reduce((a, b) => a + b, 0) * days / 7;
-            }
+            const totalSlots = calculateTotalSlots(start, end, r.chain.slotSchedule);
             const budget = totalSlots * r.chain.slotPrice * r.chain.locationCount;
             return (
               <TableRow key={i}>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,23 @@
+export function calculateTotalSlots(startDate, endDate, slotSchedule) {
+  if (!startDate || !endDate || !slotSchedule) return 0;
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  const days = Math.ceil((end - start) / (1000 * 60 * 60 * 24)) + 1;
+
+  if (slotSchedule.type === 'uniform') {
+    return (slotSchedule.slots || 0) * days;
+  }
+
+  if (slotSchedule.type === 'weekday') {
+    const weekdayCounts = Array(7).fill(0);
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+      weekdayCounts[d.getDay()]++;
+    }
+    return Object.entries(slotSchedule.slots || {}).reduce((sum, [day, count]) => {
+      const idx = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'].indexOf(day);
+      return sum + (count || 0) * (weekdayCounts[idx] || 0);
+    }, 0);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add `calculateTotalSlots` helper
- reuse new helper in CampaignForm, CampaignDetail and CampaignList

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687926bc4fe88321b40907ca4521b03c