### PR TITLE
Implement Clients table

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import ChainEdit from "./ChainEdit";
 import ManagerEdit from "./ManagerEdit";
 import Users from "./Users";
 import Clients from "./Clients";
+import ClientEdit from "./ClientEdit";
 import Login from "./Login";
 import CampaignDetail from "./CampaignDetail";
 
@@ -34,6 +35,7 @@ function App() {
     <Route path="inventory/managers/:id/edit" element={<ManagerEdit />} />
     <Route path="inventory/users" element={<Users />} />
     <Route path="clients" element={<Clients />} />
+    <Route path="clients/:id/edit" element={<ClientEdit />} />
     <Route path="login" element={<Login />} />
   </Route>
 </Routes>

--- a/src/ClientEdit.js
+++ b/src/ClientEdit.js
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { db } from "./firebase";
+import { doc, getDoc, updateDoc } from "firebase/firestore";
+import { Button, Stack, TextField } from "@mui/material";
+import PageWrapper from "./components/common/PageWrapper";
+import SectionTitle from "./components/common/SectionTitle";
+
+export default function ClientEdit() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({ name: "", legalEntity: "", taxNumber: "" });
+
+  useEffect(() => {
+    const load = async () => {
+      const snap = await getDoc(doc(db, "clients", id));
+      if (snap.exists()) {
+        const data = snap.data();
+        setFormData({
+          name: data.name || "",
+          legalEntity: data.legalEntity || "",
+          taxNumber: data.taxNumber || "",
+        });
+      }
+    };
+    load();
+  }, [id]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await updateDoc(doc(db, "clients", id), {
+      name: formData.name,
+      legalEntity: formData.legalEntity,
+      taxNumber: formData.taxNumber,
+    });
+    navigate("/clients");
+  };
+
+  return (
+    <PageWrapper>
+      <SectionTitle>Edit Client</SectionTitle>
+      <form onSubmit={handleSubmit}>
+        <Stack spacing={2} sx={{ maxWidth: 400 }}>
+          <TextField
+            label="Name"
+            size="small"
+            value={formData.name}
+            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+            required
+          />
+          <TextField
+            label="Legal Entity"
+            size="small"
+            value={formData.legalEntity}
+            onChange={(e) => setFormData({ ...formData, legalEntity: e.target.value })}
+          />
+          <TextField
+            label="Tax Number"
+            size="small"
+            value={formData.taxNumber}
+            onChange={(e) => setFormData({ ...formData, taxNumber: e.target.value })}
+          />
+          <Stack direction="row" spacing={2}>
+            <Button type="submit" variant="contained">Save</Button>
+            <Button variant="outlined" onClick={() => navigate("/clients")}>Cancel</Button>
+          </Stack>
+        </Stack>
+      </form>
+    </PageWrapper>
+  );
+}

--- a/src/Clients.js
+++ b/src/Clients.js
@@ -1,3 +1,124 @@
+import React, { useEffect, useState } from "react";
+import { db } from "./firebase";
+import { collection, getDocs, doc, setDoc, deleteDoc } from "firebase/firestore";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Button,
+  IconButton,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Stack,
+  TextField,
+} from "@mui/material";
+import { Edit, Delete, AccountTree } from "@mui/icons-material";
+import PageWrapper from "./components/common/PageWrapper";
+import SectionTitle from "./components/common/SectionTitle";
+
 export default function Clients() {
-  return <h2>Clients (auto-generated from campaigns)</h2>;
+  const [clients, setClients] = useState([]);
+  const [newClient, setNewClient] = useState({ name: "", legalEntity: "", taxNumber: "" });
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getDocs(collection(db, "clients")).then((snapshot) => {
+      setClients(snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
+    });
+  }, []);
+
+  const handleAdd = async () => {
+    if (!newClient.name) return;
+    const clientRef = doc(collection(db, "clients"));
+    await setDoc(clientRef, {
+      name: newClient.name,
+      legalEntity: newClient.legalEntity,
+      taxNumber: newClient.taxNumber,
+    });
+    setClients((prev) => [...prev, { id: clientRef.id, ...newClient }]);
+    setNewClient({ name: "", legalEntity: "", taxNumber: "" });
+  };
+
+  const handleDelete = async (id) => {
+    if (window.confirm("Delete this client?")) {
+      await deleteDoc(doc(db, "clients", id));
+      setClients((prev) => prev.filter((c) => c.id !== id));
+    }
+  };
+
+  const tableCellSx = {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    maxWidth: 120,
+    fontSize: 13,
+    p: 1,
+  };
+
+  return (
+    <PageWrapper type="wide">
+      <SectionTitle>Clients</SectionTitle>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <TextField
+          label="Name"
+          size="small"
+          value={newClient.name}
+          onChange={(e) => setNewClient({ ...newClient, name: e.target.value })}
+        />
+        <TextField
+          label="Legal Entity"
+          size="small"
+          value={newClient.legalEntity}
+          onChange={(e) => setNewClient({ ...newClient, legalEntity: e.target.value })}
+        />
+        <TextField
+          label="Tax Number"
+          size="small"
+          value={newClient.taxNumber}
+          onChange={(e) => setNewClient({ ...newClient, taxNumber: e.target.value })}
+        />
+        <Button variant="contained" onClick={handleAdd} disabled={!newClient.name}>
+          Add
+        </Button>
+      </Stack>
+      <Box sx={{ width: '100%', overflowX: "auto" }}>
+        <Table size="small" sx={{ minWidth: 700 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell sx={tableCellSx}>ID</TableCell>
+              <TableCell sx={tableCellSx}>Name</TableCell>
+              <TableCell sx={tableCellSx}>Legal Entity</TableCell>
+              <TableCell sx={tableCellSx}>Tax Number</TableCell>
+              <TableCell sx={tableCellSx}>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {clients.map((c) => (
+              <TableRow key={c.id}>
+                <TableCell sx={tableCellSx}>{c.id}</TableCell>
+                <TableCell sx={tableCellSx}>{c.name}</TableCell>
+                <TableCell sx={tableCellSx}>{c.legalEntity}</TableCell>
+                <TableCell sx={tableCellSx}>{c.taxNumber}</TableCell>
+                <TableCell sx={tableCellSx}>
+                  <Stack direction="row" spacing={0}>
+                    <IconButton size="small" onClick={() => navigate(`/clients/${c.id}/edit`)}>
+                      <Edit fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" onClick={() => navigate(`/campaigns/client/${c.id}`)}>
+                      <AccountTree fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" onClick={() => handleDelete(c.id)}>
+                      <Delete fontSize="small" />
+                    </IconButton>
+                  </Stack>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
+    </PageWrapper>
+  );
 }


### PR DESCRIPTION
## Summary
- fetch `clients` collection from Firestore
- list clients in a table with add/remove links
- add page to edit client info
- route to `/clients/:id/edit`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687926cda7a0832190469e6238a59214