### PR TITLE
Add Firestore error handling

### DIFF
--- a/src/CampaignList.js
+++ b/src/CampaignList.js
@@ -90,8 +90,13 @@ export default function CampaignList({ filteredBy }) {
 
   const deleteCampaign = async (id) => {
     if (window.confirm("Delete this campaign?")) {
-      await deleteDoc(doc(db, "campaigns", id));
-      setCampaigns(prev => prev.filter(c => c.id !== id));
+      try {
+        await deleteDoc(doc(db, "campaigns", id));
+        setCampaigns(prev => prev.filter(c => c.id !== id));
+      } catch (err) {
+        console.error(err);
+        alert("Failed to delete campaign.");
+      }
     }
   };
 

--- a/src/Campaigns.js
+++ b/src/Campaigns.js
@@ -32,16 +32,26 @@ function Campaigns({ user }) {
 
   const handleAdd = async () => {
     if (!newCampaign.name || !newCampaign.client) return;
-    await addDoc(collection(db, "campaigns"), {
-      ...newCampaign,
-      createdBy: user.email,
-      createdAt: new Date(),
-    });
-    setNewCampaign({ name: "", client: "", status: "Planned" });
+    try {
+      await addDoc(collection(db, "campaigns"), {
+        ...newCampaign,
+        createdBy: user.email,
+        createdAt: new Date(),
+      });
+      setNewCampaign({ name: "", client: "", status: "Planned" });
+    } catch (err) {
+      console.error(err);
+      alert("Failed to add campaign.");
+    }
   };
 
   const handleDelete = async (id) => {
-    await deleteDoc(doc(db, "campaigns", id));
+    try {
+      await deleteDoc(doc(db, "campaigns", id));
+    } catch (err) {
+      console.error(err);
+      alert("Failed to delete campaign.");
+    }
   };
 
   const startEdit = (campaign) =>
@@ -49,13 +59,18 @@ function Campaigns({ user }) {
 
   const handleUpdate = async () => {
     if (!editing) return;
-    await updateDoc(doc(db, "campaigns", editing.id), {
-      name: editing.name,
-      client: editing.client,
-      status: editing.status,
-      updatedAt: new Date(),
-    });
-    setEditing(null);
+    try {
+      await updateDoc(doc(db, "campaigns", editing.id), {
+        name: editing.name,
+        client: editing.client,
+        status: editing.status,
+        updatedAt: new Date(),
+      });
+      setEditing(null);
+    } catch (err) {
+      console.error(err);
+      alert("Failed to update campaign.");
+    }
   };
 
   return (

--- a/src/ChainEdit.js
+++ b/src/ChainEdit.js
@@ -24,11 +24,16 @@ export default function ChainEdit() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await updateDoc(doc(db, "chains", id), {
-      chainName: formData.chainName,
-      share: formData.share,
-    });
-    navigate("/inventory/chains");
+    try {
+      await updateDoc(doc(db, "chains", id), {
+        chainName: formData.chainName,
+        share: formData.share,
+      });
+      navigate("/inventory/chains");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to update chain.");
+    }
   };
 
   return (

--- a/src/Chains.js
+++ b/src/Chains.js
@@ -26,13 +26,18 @@ export default function Chains() {
   
   const handleAdd = async () => {
     if (!newChain.chainName || !newChain.share) return;
-    const chainRef = doc(collection(db, "chains"));
-    await setDoc(chainRef, {
-      chainName: newChain.chainName,
-      share: newChain.share,
-    });
-    setChains(prev => [...prev, { id: chainRef.id, ...newChain }]);
-    setNewChain({ chainName: "", share: "" });
+    try {
+      const chainRef = doc(collection(db, "chains"));
+      await setDoc(chainRef, {
+        chainName: newChain.chainName,
+        share: newChain.share,
+      });
+      setChains(prev => [...prev, { id: chainRef.id, ...newChain }]);
+      setNewChain({ chainName: "", share: "" });
+    } catch (err) {
+      console.error(err);
+      alert("Failed to add chain.");
+    }
   };
 
   useEffect(() => {
@@ -43,8 +48,13 @@ export default function Chains() {
 
   const handleDelete = async (id) => {
     if (window.confirm("Delete this chain?")) {
-      await deleteDoc(doc(db, "chains", id));
-      setChains(chains.filter((c) => c.id !== id));
+      try {
+        await deleteDoc(doc(db, "chains", id));
+        setChains(chains.filter((c) => c.id !== id));
+      } catch (err) {
+        console.error(err);
+        alert("Failed to delete chain.");
+      }
     }
   };
 

--- a/src/ManagerEdit.js
+++ b/src/ManagerEdit.js
@@ -24,11 +24,16 @@ export default function ManagerEdit() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await updateDoc(doc(db, "managers", id), {
-      name: formData.name,
-      lastName: formData.lastName,
-    });
-    navigate("/inventory/managers");
+    try {
+      await updateDoc(doc(db, "managers", id), {
+        name: formData.name,
+        lastName: formData.lastName,
+      });
+      navigate("/inventory/managers");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to update manager.");
+    }
   };
 
   return (

--- a/src/Managers.js
+++ b/src/Managers.js
@@ -32,19 +32,29 @@ export default function Managers() {
 
   const handleAdd = async () => {
     if (!newManager.name || !newManager.lastName) return;
-    const managerRef = doc(collection(db, "managers"));
-    await setDoc(managerRef, {
-      name: newManager.name,
-      lastName: newManager.lastName,
-    });
-    setManagers(prev => [...prev, { id: managerRef.id, ...newManager }]);
-    setNewManager({ name: "", lastName: "" });
+    try {
+      const managerRef = doc(collection(db, "managers"));
+      await setDoc(managerRef, {
+        name: newManager.name,
+        lastName: newManager.lastName,
+      });
+      setManagers(prev => [...prev, { id: managerRef.id, ...newManager }]);
+      setNewManager({ name: "", lastName: "" });
+    } catch (err) {
+      console.error(err);
+      alert("Failed to add manager.");
+    }
   };
 
   const handleDelete = async (id) => {
     if (window.confirm("Delete this manager?")) {
-      await deleteDoc(doc(db, "managers", id));
-      setManagers(managers.filter((m) => m.id !== id));
+      try {
+        await deleteDoc(doc(db, "managers", id));
+        setManagers(managers.filter((m) => m.id !== id));
+      } catch (err) {
+        console.error(err);
+        alert("Failed to delete manager.");
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- wrap Firestore calls in main async handlers with try/catch blocks
- show alert on error and log for debugging

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687926fedac08321a8bf259539d7d07b