### PR TITLE
Introduce global Auth context

### DIFF
--- a/src/Layout.js
+++ b/src/Layout.js
@@ -27,9 +27,7 @@ import {
   AccountTree,
 } from "@mui/icons-material";
 import { useNavigate } from "react-router-dom";
-import { auth } from "./firebase";
-import { signOut } from "firebase/auth";
-import { useAuthState } from "react-firebase-hooks/auth";
+import { useAuth } from "./context/AuthContext";
 import { Login, Logout } from "@mui/icons-material";
 
 const drawerWidth = 240;
@@ -40,12 +38,12 @@ export default function Layout() {
   const location = useLocation();
   
   const navigate = useNavigate();
-const [user] = useAuthState(auth);
+  const { user, logout } = useAuth();
 
-const handleLogout = async () => {
-  await signOut(auth);
-  navigate("/login");
-};
+  const handleLogout = async () => {
+    await logout();
+    navigate("/login");
+  };
 
   return (
     <Box sx={{ display: "flex" }}>

--- a/src/Login.js
+++ b/src/Login.js
@@ -1,7 +1,6 @@
 // Refactored Login.js
 import React, { useState } from "react";
-import { auth, ensureUserDoc } from "./firebase";
-import { signInWithEmailAndPassword } from "firebase/auth";
+import { useAuth } from "./context/AuthContext";
 import { useNavigate } from "react-router-dom";
 import {
   Box,
@@ -18,13 +17,13 @@ export default function Login() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const navigate = useNavigate();
+  const { login } = useAuth();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError("");
     try {
-      const userCred = await signInWithEmailAndPassword(auth, email, password);
-      await ensureUserDoc(userCred.user);
+      await login(email, password);
       navigate("/");
     } catch (err) {
       setError("Login failed. Please check your credentials.");

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext } from "react";
+import { useAuthState } from "react-firebase-hooks/auth";
+import { signInWithEmailAndPassword, signOut } from "firebase/auth";
+import { auth, ensureUserDoc } from "../firebase";
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [user, loading, error] = useAuthState(auth);
+
+  const login = async (email, password) => {
+    const userCred = await signInWithEmailAndPassword(auth, email, password);
+    await ensureUserDoc(userCred.user);
+    return userCred.user;
+  };
+
+  const logout = async () => {
+    await signOut(auth);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, error, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,15 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { BrowserRouter } from 'react-router-dom';
 import { CssBaseline } from "@mui/material";
+import { AuthProvider } from "./context/AuthContext";
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <ThemeProvider theme={theme}>
   <BrowserRouter>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </BrowserRouter>
   </ThemeProvider>
 );


### PR DESCRIPTION
## Summary
- centralize auth logic in `AuthContext`
- use context in `Layout` and `Login` components
- wrap application with provider in `index.js`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879272e21788321b6efede9654bf850