### PR TITLE
Move login route outside layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,29 +18,29 @@ import NotFound from "./NotFound";
 function App() {
   return (
     <Routes>
-  <Route path="/" element={<Layout />}>
-    <Route index element={<Navigate to="/campaigns" />} />
+      <Route path="/login" element={<Login />} />
+      <Route path="/" element={<Layout />}>
+        <Route index element={<Navigate to="/campaigns" />} />
 
-    <Route path="campaigns">
-      <Route index element={<CampaignList />} />
-      <Route path="new" element={<CampaignForm />} />
-      <Route path=":id/edit" element={<CampaignForm />} />
-      <Route path=":id" element={<CampaignDetail />} />
-      <Route path="client/:clientId" element={<CampaignList filteredBy="client" />} />
-      <Route path="manager/:managerId" element={<CampaignList filteredBy="manager" />} />
-    </Route>
+        <Route path="campaigns">
+          <Route index element={<CampaignList />} />
+          <Route path="new" element={<CampaignForm />} />
+          <Route path=":id/edit" element={<CampaignForm />} />
+          <Route path=":id" element={<CampaignDetail />} />
+          <Route path="client/:clientId" element={<CampaignList filteredBy="client" />} />
+          <Route path="manager/:managerId" element={<CampaignList filteredBy="manager" />} />
+        </Route>
 
-    <Route path="inventory/chains" element={<Chains />} />
-    <Route path="inventory/chains/:id/edit" element={<ChainEdit />} />
-    <Route path="inventory/managers" element={<Managers />} />
-    <Route path="inventory/managers/:id/edit" element={<ManagerEdit />} />
-    <Route path="inventory/users" element={<Users />} />
-    <Route path="clients" element={<Clients />} />
-    <Route path="clients/:id/edit" element={<ClientEdit />} />
-    <Route path="login" element={<Login />} />
-  </Route>
-  <Route path="*" element={<NotFound />} />
-</Routes>
+        <Route path="inventory/chains" element={<Chains />} />
+        <Route path="inventory/chains/:id/edit" element={<ChainEdit />} />
+        <Route path="inventory/managers" element={<Managers />} />
+        <Route path="inventory/managers/:id/edit" element={<ManagerEdit />} />
+        <Route path="inventory/users" element={<Users />} />
+        <Route path="clients" element={<Clients />} />
+        <Route path="clients/:id/edit" element={<ClientEdit />} />
+      </Route>
+      <Route path="*" element={<NotFound />} />
+    </Routes>
 
   );
 }

--- a/src/Login.js
+++ b/src/Login.js
@@ -1,7 +1,7 @@
 // Refactored Login.js
 import React, { useState } from "react";
 import { useAuth } from "./context/AuthContext";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Navigate } from "react-router-dom";
 import {
   Box,
   Button,
@@ -17,14 +17,18 @@ export default function Login() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const navigate = useNavigate();
-  const { login } = useAuth();
+  const { login, user } = useAuth();
+
+  if (user) {
+    return <Navigate to="/campaigns" replace />;
+  }
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError("");
     try {
       await login(email, password);
-      navigate("/");
+      navigate("/campaigns");
     } catch (err) {
       setError("Login failed. Please check your credentials.");
     }


### PR DESCRIPTION
## Summary
- place `/login` route at root level
- redirect authenticated users away from login to campaigns

## Testing
- `npm test --silent --runInBand` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879399f38888321a6ca1fc1ddb8d53d