### PR TITLE
Improve Firestore error handling

### DIFF
--- a/src/CampaignForm.js
+++ b/src/CampaignForm.js
@@ -195,9 +195,14 @@ export default function CampaignForm() {
         alert("Duplicate or missing client name");
         return;
       }
-      const clientRef = doc(collection(db, "clients"));
-      await setDoc(clientRef, { ...newClient, createdAt: Timestamp.now() });
-      clientId = clientRef.id;
+      try {
+        const clientRef = doc(collection(db, "clients"));
+        await setDoc(clientRef, { ...newClient, createdAt: Timestamp.now() });
+        clientId = clientRef.id;
+      } catch (err) {
+        alert("Failed to add new client.");
+        return;
+      }
     }
 
     // Get existing campaign (edit mode) to preserve createdAt
@@ -223,8 +228,12 @@ export default function CampaignForm() {
     };
 
     const campaignId = isEdit ? id : `C_${Date.now()}`;
-    await setDoc(doc(db, "campaigns", campaignId), payload);
-    navigate("/campaigns");
+    try {
+      await setDoc(doc(db, "campaigns", campaignId), payload);
+      navigate("/campaigns");
+    } catch (err) {
+      alert("Failed to save campaign.");
+    }
   };
 
   const handleChainAddOrUpdate = () => {

--- a/src/CampaignList.js
+++ b/src/CampaignList.js
@@ -98,8 +98,12 @@ export default function CampaignList({ filteredBy }) {
 
   const deleteCampaign = async (id) => {
     if (window.confirm("Delete this campaign?")) {
-      await deleteDoc(doc(db, "campaigns", id));
-      setCampaigns(prev => prev.filter(c => c.id !== id));
+      try {
+        await deleteDoc(doc(db, "campaigns", id));
+        setCampaigns(prev => prev.filter(c => c.id !== id));
+      } catch (err) {
+        alert("Failed to delete campaign.");
+      }
     }
   };
 

--- a/src/ChainEdit.js
+++ b/src/ChainEdit.js
@@ -29,11 +29,15 @@ export default function ChainEdit() {
       alert("Share cannot be negative");
       return;
     }
-    await updateDoc(doc(db, "chains", id), {
-      chainName: formData.chainName,
-      share: shareNum,
-    });
-    navigate("/inventory/chains");
+    try {
+      await updateDoc(doc(db, "chains", id), {
+        chainName: formData.chainName,
+        share: shareNum,
+      });
+      navigate("/inventory/chains");
+    } catch (err) {
+      alert("Failed to save chain.");
+    }
   };
 
   return (

--- a/src/Chains.js
+++ b/src/Chains.js
@@ -31,13 +31,17 @@ export default function Chains() {
       alert("Share cannot be negative");
       return;
     }
-    const chainRef = doc(collection(db, "chains"));
-    await setDoc(chainRef, {
-      chainName: newChain.chainName,
-      share: shareNum,
-    });
-    setChains(prev => [...prev, { id: chainRef.id, chainName: newChain.chainName, share: shareNum }]);
-    setNewChain({ chainName: "", share: "" });
+    try {
+      const chainRef = doc(collection(db, "chains"));
+      await setDoc(chainRef, {
+        chainName: newChain.chainName,
+        share: shareNum,
+      });
+      setChains(prev => [...prev, { id: chainRef.id, chainName: newChain.chainName, share: shareNum }]);
+      setNewChain({ chainName: "", share: "" });
+    } catch (err) {
+      alert("Failed to add chain.");
+    }
   };
 
   useEffect(() => {
@@ -48,8 +52,12 @@ export default function Chains() {
 
   const handleDelete = async (id) => {
     if (window.confirm("Delete this chain?")) {
-      await deleteDoc(doc(db, "chains", id));
-      setChains(chains.filter((c) => c.id !== id));
+      try {
+        await deleteDoc(doc(db, "chains", id));
+        setChains(chains.filter((c) => c.id !== id));
+      } catch (err) {
+        alert("Failed to delete chain.");
+      }
     }
   };
 

--- a/src/ClientEdit.js
+++ b/src/ClientEdit.js
@@ -28,12 +28,16 @@ export default function ClientEdit() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await updateDoc(doc(db, "clients", id), {
-      name: formData.name,
-      legalEntity: formData.legalEntity,
-      taxNumber: formData.taxNumber,
-    });
-    navigate("/clients");
+    try {
+      await updateDoc(doc(db, "clients", id), {
+        name: formData.name,
+        legalEntity: formData.legalEntity,
+        taxNumber: formData.taxNumber,
+      });
+      navigate("/clients");
+    } catch (err) {
+      alert("Failed to save client.");
+    }
   };
 
   return (

--- a/src/Clients.js
+++ b/src/Clients.js
@@ -31,20 +31,28 @@ export default function Clients() {
 
   const handleAdd = async () => {
     if (!newClient.name) return;
-    const clientRef = doc(collection(db, "clients"));
-    await setDoc(clientRef, {
-      name: newClient.name,
-      legalEntity: newClient.legalEntity,
-      taxNumber: newClient.taxNumber,
-    });
-    setClients((prev) => [...prev, { id: clientRef.id, ...newClient }]);
-    setNewClient({ name: "", legalEntity: "", taxNumber: "" });
+    try {
+      const clientRef = doc(collection(db, "clients"));
+      await setDoc(clientRef, {
+        name: newClient.name,
+        legalEntity: newClient.legalEntity,
+        taxNumber: newClient.taxNumber,
+      });
+      setClients((prev) => [...prev, { id: clientRef.id, ...newClient }]);
+      setNewClient({ name: "", legalEntity: "", taxNumber: "" });
+    } catch (err) {
+      alert("Failed to add client.");
+    }
   };
 
   const handleDelete = async (id) => {
     if (window.confirm("Delete this client?")) {
-      await deleteDoc(doc(db, "clients", id));
-      setClients((prev) => prev.filter((c) => c.id !== id));
+      try {
+        await deleteDoc(doc(db, "clients", id));
+        setClients((prev) => prev.filter((c) => c.id !== id));
+      } catch (err) {
+        alert("Failed to delete client.");
+      }
     }
   };
 

--- a/src/ManagerEdit.js
+++ b/src/ManagerEdit.js
@@ -24,11 +24,15 @@ export default function ManagerEdit() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await updateDoc(doc(db, "managers", id), {
-      name: formData.name,
-      lastName: formData.lastName,
-    });
-    navigate("/inventory/managers");
+    try {
+      await updateDoc(doc(db, "managers", id), {
+        name: formData.name,
+        lastName: formData.lastName,
+      });
+      navigate("/inventory/managers");
+    } catch (err) {
+      alert("Failed to save manager.");
+    }
   };
 
   return (

--- a/src/Managers.js
+++ b/src/Managers.js
@@ -32,19 +32,27 @@ export default function Managers() {
 
   const handleAdd = async () => {
     if (!newManager.name || !newManager.lastName) return;
-    const managerRef = doc(collection(db, "managers"));
-    await setDoc(managerRef, {
-      name: newManager.name,
-      lastName: newManager.lastName,
-    });
-    setManagers(prev => [...prev, { id: managerRef.id, ...newManager }]);
-    setNewManager({ name: "", lastName: "" });
+    try {
+      const managerRef = doc(collection(db, "managers"));
+      await setDoc(managerRef, {
+        name: newManager.name,
+        lastName: newManager.lastName,
+      });
+      setManagers(prev => [...prev, { id: managerRef.id, ...newManager }]);
+      setNewManager({ name: "", lastName: "" });
+    } catch (err) {
+      alert("Failed to add manager.");
+    }
   };
 
   const handleDelete = async (id) => {
     if (window.confirm("Delete this manager?")) {
-      await deleteDoc(doc(db, "managers", id));
-      setManagers(managers.filter((m) => m.id !== id));
+      try {
+        await deleteDoc(doc(db, "managers", id));
+        setManagers(managers.filter((m) => m.id !== id));
+      } catch (err) {
+        alert("Failed to delete manager.");
+      }
     }
   };
 

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -22,9 +22,13 @@ export const ensureUserDoc = async (user) => {
   const ref = doc(db, "users", user.uid);
   const snapshot = await getDoc(ref);
   if (!snapshot.exists()) {
-    await setDoc(ref, {
-      email: user.email,
-      role: "Viewer"
-    });
+    try {
+      await setDoc(ref, {
+        email: user.email,
+        role: "Viewer"
+      });
+    } catch (err) {
+      console.error("Failed to create user document", err);
+    }
   }
 };


### PR DESCRIPTION
## Summary
- wrap Firestore writes and deletes in `try/catch`
- show alert messages on write/delete failures

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68793caaeb9883218484e1be40d6eb99