### PR TITLE
Add fallback NotFound route

### DIFF
--- a/src/NotFound.js
+++ b/src/NotFound.js
@@ -1,12 +1,13 @@
 import React from "react";
-import PageWrapper from "./components/common/PageWrapper";
-import SectionTitle from "./components/common/SectionTitle";
+import { Box, Typography } from "@mui/material";
 
 export default function NotFound() {
   return (
-    <PageWrapper>
-      <SectionTitle>Page Not Found</SectionTitle>
-      <p>The page you are looking for does not exist.</p>
-    </PageWrapper>
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" gutterBottom>
+        Page Not Found
+      </Typography>
+      <Typography>The page you are looking for does not exist.</Typography>
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary
- simplify the `NotFound` component
- keep `path="*"` route at the end of the app router

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879447d19888321925c8d072361d3bb