### PR TITLE
Add updated timestamp to CampaignDetail

### DIFF
--- a/src/CampaignDetail.js
+++ b/src/CampaignDetail.js
@@ -51,6 +51,13 @@ export default function CampaignDetail() {
         ? new Date(campaign.createdAt).toLocaleDateString()
         : "";
 
+  const updated =
+    campaign.updatedAt?.toDate
+      ? campaign.updatedAt.toDate().toLocaleDateString()
+      : campaign.updatedAt
+        ? new Date(campaign.updatedAt).toLocaleDateString()
+        : "";
+
   return (
     <div style={{ maxWidth: 800, margin: "0 auto", padding: 20 }}>
       <h2>📛 {campaign.campaignName}</h2>
@@ -59,6 +66,7 @@ export default function CampaignDetail() {
       <p><b>Manager:</b> {managerName}</p>
       <p><b>Status:</b> {campaign.status}</p>
       <p><b>Created:</b> {created}</p>
+      <p><b>Updated:</b> {updated}</p>
       <p><b>Total Budget:</b> {(campaign.budget || 0).toLocaleString()} AMD</p>
 
       <hr />

--- a/src/CampaignDetail.test.js
+++ b/src/CampaignDetail.test.js
@@ -47,3 +47,28 @@ test('renders without crashing when createdAt is missing', async () => {
     expect(screen.getByText(/No Date/)).toBeInTheDocument();
   });
 });
+
+test('displays Updated field when updatedAt is provided', async () => {
+  const campaignData = {
+    campaignName: 'With Update',
+    status: 'active',
+    clientId: 'client1',
+    managerId: 'manager1',
+    createdAt: { toDate: () => new Date('2020-01-01') },
+    updatedAt: { toDate: () => new Date('2020-01-02') },
+    chains: [],
+  };
+
+  mockGetDoc
+    .mockResolvedValueOnce({ exists: () => true, data: () => campaignData })
+    .mockResolvedValueOnce({ exists: () => true, data: () => ({ name: 'C1' }) })
+    .mockResolvedValueOnce({ exists: () => true, data: () => ({ name: 'M1' }) });
+
+  mockGetDocs.mockResolvedValueOnce({ forEach: () => {} });
+
+  render(<CampaignDetail />);
+
+  await waitFor(() => {
+    expect(screen.getByText(/Updated:/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- display updated timestamp in CampaignDetail
- verify updated timestamp renders when provided

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879e88b86d883219bf3c9d096cee601