### PR TITLE
Centralize table cell styles

### DIFF
--- a/src/CampaignList.js
+++ b/src/CampaignList.js
@@ -18,6 +18,7 @@ import { Edit, Delete } from "@mui/icons-material";
 import PageWrapper from "./components/common/PageWrapper";
 import SectionTitle from "./components/common/SectionTitle";
 import { calculateTotalSlots } from "./utils";
+import { tableCellSx } from "./components/common/tableStyles";
 
 export default function CampaignList({ filteredBy }) {
   const [campaigns, setCampaigns] = useState([]);
@@ -107,14 +108,6 @@ export default function CampaignList({ filteredBy }) {
     }
   };
 
-  const tableCellSx = {
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  maxWidth: 120,
-  fontSize: 13,
-  p: 1,
-};
 
 const renderGeneral = () => (
   <Box sx={{ width: '100%', overflowX: "auto" }}>

--- a/src/Chains.js
+++ b/src/Chains.js
@@ -18,6 +18,7 @@ import {
 import { Edit, Delete } from "@mui/icons-material";
 import PageWrapper from "./components/common/PageWrapper";
 import SectionTitle from "./components/common/SectionTitle";
+import { tableCellSx } from "./components/common/tableStyles";
 
 export default function Chains() {
   const [chains, setChains] = useState([]);
@@ -63,15 +64,6 @@ export default function Chains() {
         setSubmitError("Failed to delete chain.");
       }
     }
-  };
-
-  const tableCellSx = {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    maxWidth: 120,
-    fontSize: 13,
-    p: 1,
   };
 
   return (

--- a/src/Clients.js
+++ b/src/Clients.js
@@ -17,6 +17,7 @@ import {
 import { Edit, Delete, AccountTree } from "@mui/icons-material";
 import PageWrapper from "./components/common/PageWrapper";
 import SectionTitle from "./components/common/SectionTitle";
+import { tableCellSx } from "./components/common/tableStyles";
 
 export default function Clients() {
   const [clients, setClients] = useState([]);
@@ -54,15 +55,6 @@ export default function Clients() {
         alert("Failed to delete client.");
       }
     }
-  };
-
-  const tableCellSx = {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    maxWidth: 120,
-    fontSize: 13,
-    p: 1,
   };
 
   return (

--- a/src/Managers.js
+++ b/src/Managers.js
@@ -18,6 +18,7 @@ import {
 import { Edit, Delete } from "@mui/icons-material";
 import PageWrapper from "./components/common/PageWrapper";
 import SectionTitle from "./components/common/SectionTitle";
+import { tableCellSx } from "./components/common/tableStyles";
 
 export default function Managers() {
   const [managers, setManagers] = useState([]);
@@ -54,15 +55,6 @@ export default function Managers() {
         alert("Failed to delete manager.");
       }
     }
-  };
-
-  const tableCellSx = {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    maxWidth: 120,
-    fontSize: 13,
-    p: 1,
   };
 
   return (

--- a/src/Users.js
+++ b/src/Users.js
@@ -14,6 +14,7 @@ import {
 } from "@mui/material";
 import PageWrapper from "./components/common/PageWrapper";
 import SectionTitle from "./components/common/SectionTitle";
+import { tableCellSx } from "./components/common/tableStyles";
 
 const ROLES = ["Admin", "Manager", "Account Manager", "Sales Manager", "Viewer"];
 
@@ -33,15 +34,6 @@ export default function Users() {
     } catch (err) {
       alert("Failed to update role.");
     }
-  };
-
-  const tableCellSx = {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    maxWidth: 120,
-    fontSize: 13,
-    p: 1,
   };
 
   return (

--- a/src/components/common/tableStyles.js
+++ b/src/components/common/tableStyles.js
@@ -1,0 +1,8 @@
+export const tableCellSx = {
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  maxWidth: 120,
+  fontSize: 13,
+  p: 1,
+};


### PR DESCRIPTION
## Summary
- share common `tableCellSx` style through `src/components/common/tableStyles.js`
- import new style helper into list components

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879fc4deaf483218c1dabb937bcaa68