### PR TITLE
Remove placeholder test and add NotFound test

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/NotFound.test.js
+++ b/src/NotFound.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import NotFound from './NotFound';
+
+test('displays page not found message', () => {
+  render(<NotFound />);
+  expect(screen.getByText(/Page Not Found/i)).toBeInTheDocument();
+  expect(screen.getByText(/does not exist/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- delete unused default test
- add a real test for NotFound component

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879fda89bb483218e01777765323bf8