### PR TITLE
Implement calendar views and chain colors

### DIFF
--- a/src/ChainEdit.js
+++ b/src/ChainEdit.js
@@ -9,7 +9,7 @@ import SectionTitle from "./components/common/SectionTitle";
 export default function ChainEdit() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const [formData, setFormData] = useState({ chainName: "", share: "" });
+  const [formData, setFormData] = useState({ chainName: "", share: "", color: "#1976d2" });
   const [shareError, setShareError] = useState("");
   const [submitError, setSubmitError] = useState("");
 
@@ -18,7 +18,11 @@ export default function ChainEdit() {
       const snap = await getDoc(doc(db, "chains", id));
       if (snap.exists()) {
         const data = snap.data();
-        setFormData({ chainName: data.chainName || "", share: data.share || "" });
+        setFormData({
+          chainName: data.chainName || "",
+          share: data.share || "",
+          color: data.color || "#1976d2",
+        });
       }
     };
     load();
@@ -37,6 +41,7 @@ export default function ChainEdit() {
       await updateDoc(doc(db, "chains", id), {
         chainName: formData.chainName,
         share: shareNum,
+        color: formData.color,
       });
       navigate("/inventory/chains");
     } catch (err) {
@@ -65,11 +70,19 @@ export default function ChainEdit() {
             onChange={(e) => setFormData({ ...formData, share: e.target.value })}
             required
             error={!!shareError}
-            helperText={shareError}
-          />
-          {submitError && (
-            <Typography color="error">{submitError}</Typography>
-          )}
+          helperText={shareError}
+        />
+        <TextField
+          label="Color"
+          type="color"
+          size="small"
+          value={formData.color}
+          onChange={(e) => setFormData({ ...formData, color: e.target.value })}
+          sx={{ width: 70 }}
+        />
+        {submitError && (
+          <Typography color="error">{submitError}</Typography>
+        )}
           <Stack direction="row" spacing={2}>
             <Button type="submit" variant="contained">Save</Button>
             <Button variant="outlined" onClick={() => navigate("/inventory/chains")}>Cancel</Button>

--- a/src/Chains.js
+++ b/src/Chains.js
@@ -22,7 +22,7 @@ import { tableCellSx } from "./components/common/tableStyles";
 
 export default function Chains() {
   const [chains, setChains] = useState([]);
-  const [newChain, setNewChain] = useState({ chainName: "", share: "" });
+  const [newChain, setNewChain] = useState({ chainName: "", share: "", color: "#1976d2" });
   const [shareError, setShareError] = useState("");
   const [submitError, setSubmitError] = useState("");
   const navigate = useNavigate();
@@ -41,9 +41,10 @@ export default function Chains() {
       await setDoc(chainRef, {
         chainName: newChain.chainName,
         share: shareNum,
+        color: newChain.color,
       });
-      setChains(prev => [...prev, { id: chainRef.id, chainName: newChain.chainName, share: shareNum }]);
-      setNewChain({ chainName: "", share: "" });
+      setChains(prev => [...prev, { id: chainRef.id, chainName: newChain.chainName, share: shareNum, color: newChain.color }]);
+      setNewChain({ chainName: "", share: "", color: "#1976d2" });
     } catch (err) {
       setSubmitError("Failed to add chain.");
     }
@@ -86,6 +87,14 @@ export default function Chains() {
           error={!!shareError}
           helperText={shareError}
         />
+        <TextField
+          label="Color"
+          type="color"
+          size="small"
+          value={newChain.color}
+          onChange={e => setNewChain({ ...newChain, color: e.target.value })}
+          sx={{ width: 70 }}
+        />
         <Button
           variant="contained"
           onClick={handleAdd}
@@ -106,15 +115,19 @@ export default function Chains() {
               <TableCell sx={tableCellSx}>ID</TableCell>
               <TableCell sx={tableCellSx}>Name</TableCell>
               <TableCell sx={tableCellSx}>Share (%)</TableCell>
+              <TableCell sx={tableCellSx}>Color</TableCell>
               <TableCell sx={tableCellSx}>Actions</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
-            {chains.map((chain) => (
+              {chains.map((chain) => (
               <TableRow key={chain.id}>
                 <TableCell sx={tableCellSx}>{chain.id}</TableCell>
                 <TableCell sx={tableCellSx}>{chain.chainName}</TableCell>
                 <TableCell sx={tableCellSx}>{chain.share}</TableCell>
+                <TableCell sx={tableCellSx}>
+                  <Box sx={{ width: 20, height: 20, bgcolor: chain.color || "#1976d2", borderRadius: 0.5, border: '1px solid #ccc' }} />
+                </TableCell>
                 <TableCell sx={tableCellSx}>
                   <Stack direction="row" spacing={0}>
                     <IconButton size="small" onClick={() => navigate(`/inventory/chains/${chain.id}/edit`)}><Edit fontSize="small" /></IconButton>


### PR DESCRIPTION
## Summary
- allow choosing chain colors in Chains inventory and edit views
- color events in placement calendar based on chain
- add daily/weekly/monthly view switcher
- show location counts when clicking events

## Testing
- `CI=true npm test -- -u` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_687a0dd939fc832183422a975cabbafb