### PR TITLE
Implement control panel and access management

### DIFF
--- a/src/AccessManagement.js
+++ b/src/AccessManagement.js
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from "react";
+import { collection, doc, onSnapshot, setDoc } from "firebase/firestore";
+import { Box, Checkbox, Table, TableHead, TableRow, TableCell, TableBody, Stack, Button } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+import PageWrapper from "./components/common/PageWrapper";
+import SectionTitle from "./components/common/SectionTitle";
+import { tableCellSx } from "./components/common/tableStyles";
+import { db } from "./firebase";
+
+const ROLES = ["Admin", "Manager", "Account Manager", "Sales Manager", "Viewer"];
+
+const FUNCTIONS = [
+  { id: "inventory", label: "Inventory Management" },
+  { id: "clients", label: "Clients" },
+  { id: "campaigns", label: "Campaigns" },
+  { id: "calendar", label: "Calendar" },
+  { id: "users", label: "Users & Roles" },
+];
+
+export default function AccessManagement() {
+  const [permissions, setPermissions] = useState({});
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const unsub = onSnapshot(collection(db, "permissions"), (snapshot) => {
+      const data = {};
+      snapshot.forEach((docSnap) => {
+        data[docSnap.id] = docSnap.data();
+      });
+      setPermissions(data);
+    });
+    return unsub;
+  }, []);
+
+  const togglePermission = async (funcId, role) => {
+    const current = permissions[funcId]?.[role] || false;
+    await setDoc(doc(db, "permissions", funcId), { [role]: !current }, { merge: true });
+  };
+
+  return (
+    <PageWrapper type="wide">
+      <SectionTitle>Access Management</SectionTitle>
+      <Box sx={{ width: '100%', overflowX: 'auto' }}>
+        <Table size="small" aria-label="access table" sx={{ minWidth: 700 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell sx={tableCellSx}>Functionality</TableCell>
+              {ROLES.map((r) => (
+                <TableCell key={r} sx={tableCellSx}>{r}</TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {FUNCTIONS.map((f) => (
+              <TableRow key={f.id}>
+                <TableCell sx={tableCellSx}>{f.label}</TableCell>
+                {ROLES.map((r) => (
+                  <TableCell key={r} sx={tableCellSx}>
+                    <Checkbox
+                      checked={permissions[f.id]?.[r] || false}
+                      onChange={() => togglePermission(f.id, r)}
+                      size="small"
+                    />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
+      <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
+        <Button variant="outlined" onClick={() => navigate(-1)}>Close</Button>
+      </Stack>
+    </PageWrapper>
+  );
+}

--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ import NotFound from "./NotFound";
 import RequireRole from "./components/auth/RequireRole";
 import RequireAuth from "./components/auth/RequireAuth";
 import Profile from "./Profile";
+import AccessManagement from "./AccessManagement";
 
 function App() {
   return (
@@ -74,6 +75,14 @@ function App() {
           element={
             <RequireRole role="Admin">
               <Users />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="control/access"
+          element={
+            <RequireRole role="Admin">
+              <AccessManagement />
             </RequireRole>
           }
         />

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -27,6 +27,8 @@ import {
   AccountTree,
   CalendarMonth,
   AccountCircle,
+  AdminPanelSettings,
+  Security,
 } from "@mui/icons-material";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "./context/AuthContext";
@@ -37,10 +39,11 @@ const drawerWidth = 240;
 export default function Layout() {
   const [open, setOpen] = useState(true);
   const [inventoryOpen, setInventoryOpen] = useState(false);
+  const [controlOpen, setControlOpen] = useState(false);
   const location = useLocation();
   
   const navigate = useNavigate();
-  const { user, logout } = useAuth();
+  const { user, logout, role } = useAuth();
 
   const handleLogout = async () => {
     await logout();
@@ -144,6 +147,29 @@ export default function Layout() {
             <ListItemIcon><CalendarMonth /></ListItemIcon>
             <ListItemText primary="Calendar" />
           </ListItemButton>
+
+          {user && role === "Admin" && (
+            <>
+              <ListItemButton onClick={() => setControlOpen(!controlOpen)}>
+                <ListItemIcon><AdminPanelSettings /></ListItemIcon>
+                <ListItemText primary="Control Panel" />
+                {controlOpen ? <ExpandLess /> : <ExpandMore />}
+              </ListItemButton>
+              <Collapse in={controlOpen} timeout="auto" unmountOnExit>
+                <List component="div" disablePadding>
+                  <ListItemButton
+                    component={Link}
+                    to="/control/access"
+                    selected={location.pathname === "/control/access"}
+                    sx={{ pl: 4 }}
+                  >
+                    <ListItemIcon><Security /></ListItemIcon>
+                    <ListItemText primary="Access Management" />
+                  </ListItemButton>
+                </List>
+              </Collapse>
+            </>
+          )}
 
           {!user && (
             <ListItemButton

--- a/src/Profile.js
+++ b/src/Profile.js
@@ -6,10 +6,12 @@ import { updatePassword } from "firebase/auth";
 import { Button, Stack, TextField } from "@mui/material";
 import PageWrapper from "./components/common/PageWrapper";
 import SectionTitle from "./components/common/SectionTitle";
+import { useNavigate } from "react-router-dom";
 
 export default function Profile() {
   const { user } = useAuth();
-  const [formData, setFormData] = useState({ name: "", lastName: "", password: "" });
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({ name: "", lastName: "", email: "", password: "" });
 
   useEffect(() => {
     const load = async () => {
@@ -17,7 +19,14 @@ export default function Profile() {
       const snap = await getDoc(doc(db, "users", user.uid));
       if (snap.exists()) {
         const data = snap.data();
-        setFormData((prev) => ({ ...prev, name: data.name || "", lastName: data.lastName || "" }));
+        setFormData((prev) => ({
+          ...prev,
+          name: data.name || "",
+          lastName: data.lastName || "",
+          email: user.email || "",
+        }));
+      } else {
+        setFormData((prev) => ({ ...prev, email: user.email || "" }));
       }
     };
     load();
@@ -47,6 +56,12 @@ export default function Profile() {
       <form onSubmit={handleSubmit}>
         <Stack spacing={2} sx={{ maxWidth: 400 }}>
           <TextField
+            label="Email"
+            size="small"
+            value={formData.email}
+            InputProps={{ readOnly: true }}
+          />
+          <TextField
             label="Name"
             size="small"
             value={formData.name}
@@ -65,7 +80,10 @@ export default function Profile() {
             value={formData.password}
             onChange={(e) => setFormData({ ...formData, password: e.target.value })}
           />
-          <Button variant="contained" type="submit">Save</Button>
+          <Stack direction="row" spacing={2}>
+            <Button variant="contained" type="submit">Save</Button>
+            <Button variant="outlined" onClick={() => navigate(-1)}>Close</Button>
+          </Stack>
         </Stack>
       </form>
     </PageWrapper>


### PR DESCRIPTION
## Summary
- show email and add close button on profile page
- add Control Panel menu with Access Management for admins
- implement Access Management feature to toggle role permissions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a430fa6948321a78a61efe63e8ac8