### PR TITLE
Fix invite email sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ REACT_APP_FIREBASE_PROJECT_ID=<your_firebase_project_id>
 REACT_APP_FIREBASE_STORAGE_BUCKET=<your_firebase_storage_bucket>
 REACT_APP_FIREBASE_MESSAGING_SENDER_ID=<your_firebase_messaging_sender_id>
 REACT_APP_FIREBASE_APP_ID=<your_firebase_app_id>
+REACT_APP_EMAIL_ENDPOINT=<cloud_function_url>
+
+# Email SMTP credentials for the function
+SMTP_HOST=<smtp_host>
+SMTP_PORT=<smtp_port>
+SMTP_USER=<smtp_user>
+SMTP_PASS=<smtp_password>
+SMTP_FROM=<from_email_optional>
 ```
 
 These values are used by `src/firebase.js` to configure Firebase.
+The `REACT_APP_EMAIL_ENDPOINT` should point to the deployed cloud function
+`sendInviteEmail`. The SMTP variables are required when deploying the function
+so it can relay emails using your mail server.
+
+### Deploying Cloud Functions
+
+Run `npm install` inside the `functions` folder and then deploy the function:
+
+```bash
+firebase deploy --only functions
+```

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "functions": {
+    "source": "functions"
+  },
   "hosting": {
     "public": "build",
     "ignore": [

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,39 @@
+import functions from 'firebase-functions';
+import admin from 'firebase-admin';
+import nodemailer from 'nodemailer';
+
+admin.initializeApp();
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: parseInt(process.env.SMTP_PORT || '587', 10),
+  secure: false,
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
+export const sendInviteEmail = functions.https.onRequest(async (req, res) => {
+  if (req.method !== 'POST') {
+    res.status(405).send('Method Not Allowed');
+    return;
+  }
+  const { to, link, subject } = req.body || {};
+  if (!to || !link) {
+    res.status(400).send('Missing params');
+    return;
+  }
+  try {
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      to,
+      subject: subject || 'Invite',
+      text: `Please complete your registration: ${link}`,
+    });
+    res.status(200).send('sent');
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('fail');
+  }
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "functions",
+  "type": "module",
+  "engines": {
+    "node": "18"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "nodemailer": "^6.9.11"
+  }
+}

--- a/src/Users.js
+++ b/src/Users.js
@@ -75,16 +75,20 @@ export default function Users() {
     const link = `${window.location.origin}/register/${token}`;
     console.log("Invite link for", email, link);
     const endpoint = process.env.REACT_APP_EMAIL_ENDPOINT;
-    if (endpoint) {
-      try {
-        await fetch(endpoint, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ to: email, link, subject: "IMCS Invite" }),
-        });
-      } catch (e) {
-        console.error("Email send failed", e);
-      }
+    if (!endpoint) {
+      alert("Email service not configured");
+      return;
+    }
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ to: email, link, subject: "IMCS Invite" }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+    } catch (e) {
+      console.error("Email send failed", e);
+      alert("Failed to send email");
     }
   };
 


### PR DESCRIPTION
## Summary
- add Firebase Cloud Function to send invite emails via SMTP
- show errors when email service is not configured
- document email environment variables and function deployment
- configure Firebase to deploy functions

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687a6782f1808321b3955cfce2cc1258