### PR TITLE
Add mailing config and invite cancel features

### DIFF
--- a/src/AccessManagement.js
+++ b/src/AccessManagement.js
@@ -25,6 +25,7 @@ const FUNCTIONS = [
   { id: "campaigns", label: "Campaigns" },
   { id: "calendar", label: "Calendar" },
   { id: "users", label: "Users & Roles" },
+  { id: "control", label: "Control Panel" },
 ];
 
 export default function AccessManagement() {

--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import RequireRole from "./components/auth/RequireRole";
 import RequireAuth from "./components/auth/RequireAuth";
 import Profile from "./Profile";
 import AccessManagement from "./AccessManagement";
+import MailingConfig from "./MailingConfig";
 
 function App() {
   return (
@@ -94,6 +95,14 @@ function App() {
           element={
             <RequireRole role="Admin">
               <AccessManagement />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="control/mailing"
+          element={
+            <RequireRole role="Admin">
+              <MailingConfig />
             </RequireRole>
           }
         />

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -29,6 +29,7 @@ import {
   AccountCircle,
   AdminPanelSettings,
   Security,
+  Email,
 } from "@mui/icons-material";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "./context/AuthContext";
@@ -165,6 +166,15 @@ export default function Layout() {
                   >
                     <ListItemIcon><Security /></ListItemIcon>
                     <ListItemText primary="Access Management" />
+                  </ListItemButton>
+                  <ListItemButton
+                    component={Link}
+                    to="/control/mailing"
+                    selected={location.pathname === "/control/mailing"}
+                    sx={{ pl: 4 }}
+                  >
+                    <ListItemIcon><Email /></ListItemIcon>
+                    <ListItemText primary="Mailing Configuration" />
                   </ListItemButton>
                 </List>
               </Collapse>

--- a/src/MailingConfig.js
+++ b/src/MailingConfig.js
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from "react";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import { Button, Stack, TextField } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+import PageWrapper from "./components/common/PageWrapper";
+import SectionTitle from "./components/common/SectionTitle";
+import { db } from "./firebase";
+
+export default function MailingConfig() {
+  const [formData, setFormData] = useState({
+    endpoint: "",
+    smtpHost: "",
+    smtpPort: "",
+    smtpUser: "",
+    smtpPass: "",
+    smtpFrom: "",
+  });
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const snap = await getDoc(doc(db, "config", "mailing"));
+        if (snap.exists()) {
+          setFormData((prev) => ({ ...prev, ...snap.data() }));
+        }
+      } catch (err) {
+        console.error("Failed to load mailing config", err);
+      }
+    };
+    load();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await setDoc(doc(db, "config", "mailing"), formData, { merge: true });
+      alert("Configuration saved");
+    } catch (err) {
+      alert("Failed to save configuration");
+    }
+  };
+
+  return (
+    <PageWrapper>
+      <SectionTitle>Mailing Configuration</SectionTitle>
+      <form onSubmit={handleSubmit}>
+        <Stack spacing={2} sx={{ maxWidth: 400 }}>
+          <TextField
+            label="Email Endpoint"
+            size="small"
+            value={formData.endpoint}
+            onChange={(e) => setFormData({ ...formData, endpoint: e.target.value })}
+          />
+          <TextField
+            label="SMTP Host"
+            size="small"
+            value={formData.smtpHost}
+            onChange={(e) => setFormData({ ...formData, smtpHost: e.target.value })}
+          />
+          <TextField
+            label="SMTP Port"
+            size="small"
+            value={formData.smtpPort}
+            onChange={(e) => setFormData({ ...formData, smtpPort: e.target.value })}
+          />
+          <TextField
+            label="SMTP User"
+            size="small"
+            value={formData.smtpUser}
+            onChange={(e) => setFormData({ ...formData, smtpUser: e.target.value })}
+          />
+          <TextField
+            label="SMTP Password"
+            size="small"
+            type="password"
+            value={formData.smtpPass}
+            onChange={(e) => setFormData({ ...formData, smtpPass: e.target.value })}
+          />
+          <TextField
+            label="From Email"
+            size="small"
+            value={formData.smtpFrom}
+            onChange={(e) => setFormData({ ...formData, smtpFrom: e.target.value })}
+          />
+          <Stack direction="row" spacing={2}>
+            <Button type="submit" variant="contained">Save</Button>
+            <Button variant="outlined" onClick={() => navigate(-1)}>Close</Button>
+          </Stack>
+        </Stack>
+      </form>
+    </PageWrapper>
+  );
+}


### PR DESCRIPTION
## Summary
- add Mailing Configuration form under Control Panel
- enable cancelling invites in Users & Roles
- reference mailing config from invite email logic
- allow Access Management to manage Control Panel
- load SMTP config dynamically in cloud function

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b32fbb5a08321b9bd03e31f5047f8