### PR TITLE
Add mailing subject config and default admin perms

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ SMTP_PASS=<smtp_password>
 SMTP_FROM=<from_email_optional>
 ```
 
+The mailing configuration document in Firestore can also include a `subject`
+field which sets the default subject line for invite emails. This value can be
+edited from the **Mailing Configuration** screen in the application.
+
 These values are used by `src/firebase.js` to configure Firebase.
 The `REACT_APP_EMAIL_ENDPOINT` should point to the deployed cloud function
 `sendInviteEmail`. The SMTP variables are required when deploying the function

--- a/functions/index.js
+++ b/functions/index.js
@@ -36,7 +36,7 @@ export const sendInviteEmail = functions.https.onRequest(async (req, res) => {
     await transporter.sendMail({
       from: cfg.smtpFrom || process.env.SMTP_FROM || cfg.smtpUser || process.env.SMTP_USER,
       to,
-      subject: subject || 'Invite',
+      subject: subject || cfg.subject || 'Invite',
       text: `Please complete your registration: ${link}`,
     });
     res.status(200).send('sent');

--- a/src/AccessManagement.js
+++ b/src/AccessManagement.js
@@ -35,7 +35,9 @@ export default function AccessManagement() {
   useEffect(() => {
     const unsub = onSnapshot(collection(db, "permissions"), (snapshot) => {
       const data = {};
+      const existing = new Set();
       snapshot.forEach((docSnap) => {
+        existing.add(docSnap.id);
         const raw = docSnap.data();
         const entry = {};
         let needsFix = false;
@@ -58,6 +60,20 @@ export default function AccessManagement() {
           );
         }
         data[docSnap.id] = entry;
+      });
+      FUNCTIONS.forEach((f) => {
+        if (!existing.has(f.id)) {
+          const entry = {};
+          ROLES.forEach((r) => {
+            entry[r] = { read: r === "Admin", write: r === "Admin" };
+          });
+          data[f.id] = entry;
+          setDoc(
+            doc(db, "permissions", f.id),
+            { Admin: { read: true, write: true } },
+            { merge: true }
+          );
+        }
       });
       setPermissions(data);
     });

--- a/src/MailingConfig.js
+++ b/src/MailingConfig.js
@@ -14,6 +14,7 @@ export default function MailingConfig() {
     smtpUser: "",
     smtpPass: "",
     smtpFrom: "",
+    subject: "",
   });
   const navigate = useNavigate();
 
@@ -69,6 +70,7 @@ export default function MailingConfig() {
             size="small"
             value={formData.smtpUser}
             onChange={(e) => setFormData({ ...formData, smtpUser: e.target.value })}
+            inputProps={{ autoComplete: "off" }}
           />
           <TextField
             label="SMTP Password"
@@ -76,12 +78,19 @@ export default function MailingConfig() {
             type="password"
             value={formData.smtpPass}
             onChange={(e) => setFormData({ ...formData, smtpPass: e.target.value })}
+            inputProps={{ autoComplete: "new-password" }}
           />
           <TextField
             label="From Email"
             size="small"
             value={formData.smtpFrom}
             onChange={(e) => setFormData({ ...formData, smtpFrom: e.target.value })}
+          />
+          <TextField
+            label="Email Subject"
+            size="small"
+            value={formData.subject}
+            onChange={(e) => setFormData({ ...formData, subject: e.target.value })}
           />
           <Stack direction="row" spacing={2}>
             <Button type="submit" variant="contained">Save</Button>

--- a/src/Users.js
+++ b/src/Users.js
@@ -76,9 +76,14 @@ export default function Users() {
     const link = `${window.location.origin}/register/${token}`;
     console.log("Invite link for", email, link);
     let endpoint = process.env.REACT_APP_EMAIL_ENDPOINT;
+    let subject = "IMCS Invite";
     try {
       const snap = await getDoc(doc(db, "config", "mailing"));
-      endpoint = snap.exists() ? snap.data().endpoint || endpoint : endpoint;
+      if (snap.exists()) {
+        const data = snap.data();
+        endpoint = data.endpoint || endpoint;
+        subject = data.subject || subject;
+      }
     } catch (err) {
       console.error("Failed to load email config", err);
     }
@@ -90,7 +95,7 @@ export default function Users() {
       const res = await fetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ to: email, link, subject: "IMCS Invite" }),
+        body: JSON.stringify({ to: email, link, subject }),
       });
       if (!res.ok) throw new Error(await res.text());
     } catch (e) {


### PR DESCRIPTION
## Summary
- allow entering a default email subject in Mailing Configuration
- prevent SMTP fields from autofilling login credentials
- load mailing subject when sending invite emails
- read subject from config in cloud function
- create default Admin permissions for new functionalities
- document optional subject in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b38f1332883218b715276689f1dc0